### PR TITLE
Set the parent id to retrieve threads as transactions in application insight

### DIFF
--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -162,7 +162,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         RequestTelemetry req = new RequestTelemetry(name, timestamp, duration, sr.getResponseCode(), sr.getErrorCount() == 0);
         req.getContext().getOperation().setName(name);
         //Set parent id
-        req.getContext().getOperation().setParentId(Long.toString(sr.getStartTime())+Integer.toString(sr.getSampleCount()));
+        req.getContext().getOperation().setParentId(Long.toString(JMeterContextService.getTestStartTime())+sr.getThreadName());
 
         if (sr.getURL() != null) {
             req.setUrl(sr.getURL());

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -161,6 +161,8 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         Duration duration = new Duration(sr.getTime());
         RequestTelemetry req = new RequestTelemetry(name, timestamp, duration, sr.getResponseCode(), sr.getErrorCount() == 0);
         req.getContext().getOperation().setName(name);
+        //Set parent id
+        req.getContext().getOperation().setParentId(Long.toString(sr.getStartTime())+Integer.toString(sr.getSampleCount()));
 
         if (sr.getURL() != null) {
             req.setUrl(sr.getURL());


### PR DESCRIPTION
Use the test start time and thread name as Parent Id