### PR TITLE
Send response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following test results metrics are exposed by the plugin.
 - ThreadName
 - GrpThreads
 - AllThreads
+- (Optional) aih.{response_header}
 
 ### Plugin installation
 
@@ -53,6 +54,7 @@ Then, in the Parameters table, configure the following attributes.
 | *liveMetrics* | Boolean to indicate whether or not real-time metrics are enabled and available in the [Live Metrics Stream](https://docs.microsoft.com/en-us/azure/azure-monitor/app/live-stream). Defaults to `true`. | No |
 | *samplersList* | Optional list of samplers separated by a semi-colon (`;`) that the listener will collect and send metrics to Application Insights. If the list is empty, the listener will not filter samplers and send metrics from all of them. Defaults to an empty string. | No |
 | *useRegexForSamplerList* | If set to `true` the `samplersList` will be evaluated as a regex to filter samplers. Defaults to `false`. | No |
+| *responseHeaders* | Optional list of response headers spearated by a semi-colon (`;`) that the listener will collect and send values to Application Instights. | No |
 
 *Example of configuration:*
 


### PR DESCRIPTION
Added sending of arbitrary response headers.  

Some samplers return information in the response headers that is useful for performance analysis.

For example, the [BlazeMeter - Video Streaming \(HLS Plugin\)](https://github.com/Blazemeter/HLSPlugin) sampler returns the length \(time\) of the video segment in the response header X-MEDIA-SEGMENT-DURATION.  
By comparing this value with the response time, testers can determine if testers are getting sufficient performance.

I wrote an article about sending the results of Video Streaming Sampler to Application Insights using azure-backend-listener with this change applied, and displaying the results in Application Insights Workbooks.  
<https://blog.pnop.co.jp/jmeter-azure-media-services_en/>

If you find it effective, I would be happy to you adopt it.  
The response header values are assigned to a column starting with "aih.". However, you may change it to more suitable prefix.