### PR TITLE
Support for connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ Then, in the Parameters table, configure the following attributes.
 
 | Attribute | Description | Required |
 |---|---|---|
-| *instrumentationKey* | The Instrumentation Key of your Application Insights instance | Yes |
+| *connectionString* | The Connection String of your Application Insights instance | Yes |
 | *testName* | Name of the test. This value is used to differentiate metrics across test runs or plans in Application Insights and allow you to filter them. | Yes |
 | *liveMetrics* | Boolean to indicate whether or not real-time metrics are enabled and available in the [Live Metrics Stream](https://docs.microsoft.com/en-us/azure/azure-monitor/app/live-stream). Defaults to `true`. | No |
 | *samplersList* | Optional list of samplers separated by a semi-colon (`;`) that the listener will collect and send metrics to Application Insights. If the list is empty, the listener will not filter samplers and send metrics from all of them. Defaults to an empty string. | No |
 | *useRegexForSamplerList* | If set to `true` the `samplersList` will be evaluated as a regex to filter samplers. Defaults to `false`. | No |
 | *responseHeaders* | Optional list of response headers spearated by a semi-colon (`;`) that the listener will collect and send values to Application Instights. | No |
+| *instrumentationKey* | The Instrumentation Key of your Application Insights instance. Deprecated: use *connectionString* instead. | No |
 
 *Example of configuration:*
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then, in the Parameters table, configure the following attributes.
 
 | Attribute | Description | Required |
 |---|---|---|
-| *connectionString* | The Connection String of your Application Insights instance | Yes |
+| *connectionString* | The [Connection String](https://docs.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string?tabs=java) of your Application Insights instance | Yes |
 | *testName* | Name of the test. This value is used to differentiate metrics across test runs or plans in Application Insights and allow you to filter them. | Yes |
 | *liveMetrics* | Boolean to indicate whether or not real-time metrics are enabled and available in the [Live Metrics Stream](https://docs.microsoft.com/en-us/azure/azure-monitor/app/live-stream). Defaults to `true`. | No |
 | *samplersList* | Optional list of samplers separated by a semi-colon (`;`) that the listener will collect and send metrics to Application Insights. If the list is empty, the listener will not filter samplers and send metrics from all of them. Defaults to an empty string. | No |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.adrianmo</groupId>
     <artifactId>jmeter.backendlistener.azure</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.6-rc0</version>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <description>A JMeter plug-in that enables you to send test results to Azure Monitor.</description>

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -36,6 +36,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
      */
     private static final String KEY_TEST_NAME = "testName";
     private static final String KEY_INSTRUMENTATION_KEY = "instrumentationKey";
+    private static final String KEY_CONNECTION_STRING = "connectionString";
     private static final String KEY_LIVE_METRICS = "liveMetrics";
     private static final String KEY_SAMPLERS_LIST = "samplersList";
     private static final String KEY_USE_REGEX_FOR_SAMPLER_LIST = "useRegexForSamplerList";
@@ -47,7 +48,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
      * Default argument values.
      */
     private static final String DEFAULT_TEST_NAME = "jmeter";
-    private static final String DEFAULT_INSTRUMENTATION_KEY = "";
+    private static final String DEFAULT_CONNECTION_STRING = "";
     private static final boolean DEFAULT_LIVE_METRICS = true;
     private static final String DEFAULT_SAMPLERS_LIST = "";
     private static final boolean DEFAULT_USE_REGEX_FOR_SAMPLER_LIST = false;
@@ -105,7 +106,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     public Arguments getDefaultParameters() {
         Arguments arguments = new Arguments();
         arguments.addArgument(KEY_TEST_NAME, DEFAULT_TEST_NAME);
-        arguments.addArgument(KEY_INSTRUMENTATION_KEY, DEFAULT_INSTRUMENTATION_KEY);
+        arguments.addArgument(KEY_CONNECTION_STRING, DEFAULT_CONNECTION_STRING);
         arguments.addArgument(KEY_LIVE_METRICS, Boolean.toString(DEFAULT_LIVE_METRICS));
         arguments.addArgument(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST);
         arguments.addArgument(KEY_USE_REGEX_FOR_SAMPLER_LIST, Boolean.toString(DEFAULT_USE_REGEX_FOR_SAMPLER_LIST));
@@ -131,7 +132,17 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         }
 
         TelemetryConfiguration config = TelemetryConfiguration.createDefault();
-        config.setInstrumentationKey(context.getParameter(KEY_INSTRUMENTATION_KEY));
+        String instrumentationKey = context.getParameter(KEY_INSTRUMENTATION_KEY);
+        if (instrumentationKey != null) {
+            log.warn("'instrumentationKey' is deprecated, use 'connectionString' instead");
+            config.setInstrumentationKey(instrumentationKey);
+        }
+
+        String connectionString = context.getParameter(KEY_CONNECTION_STRING);
+        if (connectionString != null) {
+            config.setConnectionString(connectionString);
+        }
+
         telemetryClient = new TelemetryClient(config);
         if (liveMetrics) {
             QuickPulse.INSTANCE.initialize(config);


### PR DESCRIPTION
This PR adds support for Application Insights connection strings, which provides a more flexible way to configure connectivity to Application Insights that the plugin was lacking with Instrumentation Keys.

With connection strings, users will be able to override the Application Insights endpoint and, for example, connect to Azure China and Azure Government. 

Relates to #21 