### PR TITLE
Added option for logging response data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A JMeter plug-in that enables you to send test results to Azure Application Insi
 
 ### Description
 
-JMeter Backend Azure is a JMeter plugin enabling you to send test results to an Azure Application Insights.  
+JMeter Backend Azure is a JMeter plugin enabling you to send test results to an Azure Application Insights.
 
 The following test results metrics are exposed by the plugin.
 
@@ -29,7 +29,8 @@ The following test results metrics are exposed by the plugin.
 - ThreadName
 - GrpThreads
 - AllThreads
-- (Optional) aih.{response_header}
+- (Optional) aih.{ResponseHeader}
+- (Optional) ResponseData
 
 ### Plugin installation
 
@@ -44,8 +45,8 @@ Then, restart JMeter and the plugin should be loaded.
 
 ### JMeter configuration
 
-To make JMeter send test result metrics to Azure Application Insights, in your **Test Pan**, right click on 
-**Thread Group** > Add > Listener > Backend Listener, and choose `io.github.adrianmo.jmeter.backendlistener.azure.AzureBackendClient` as `Backend Listener Implementation`. 
+To make JMeter send test result metrics to Azure Application Insights, in your **Test Pan**, right click on
+**Thread Group** > Add > Listener > Backend Listener, and choose `io.github.adrianmo.jmeter.backendlistener.azure.AzureBackendClient` as `Backend Listener Implementation`.
 Then, in the Parameters table, configure the following attributes.
 
 | Attribute | Description | Required |
@@ -55,7 +56,8 @@ Then, in the Parameters table, configure the following attributes.
 | *liveMetrics* | Boolean to indicate whether or not real-time metrics are enabled and available in the [Live Metrics Stream](https://docs.microsoft.com/en-us/azure/azure-monitor/app/live-stream). Defaults to `true`. | No |
 | *samplersList* | Optional list of samplers separated by a semi-colon (`;`) that the listener will collect and send metrics to Application Insights. If the list is empty, the listener will not filter samplers and send metrics from all of them. Defaults to an empty string. | No |
 | *useRegexForSamplerList* | If set to `true` the `samplersList` will be evaluated as a regex to filter samplers. Defaults to `false`. | No |
-| *responseHeaders* | Optional list of response headers spearated by a semi-colon (`;`) that the listener will collect and send values to Application Instights. | No |
+| *responseHeaders* | Optional list of response headers separated by a semi-colon (`;`) that the listener will collect and send values to Application Insights. | No |
+| *logResponseData* | Boolean to indicate whether or not the response data should be captured. If set to `true`, the response data will be capture as a string into the _ResponseData_ property. Defaults to `false`. | No |
 | *instrumentationKey* | The Instrumentation Key of your Application Insights instance. <br>⚠️ **Deprecated**: use *connectionString* instead. | No |
 
 *Example of configuration:*
@@ -68,7 +70,7 @@ You can add custom data to your metrics by adding properties starting with `ai.`
 
 ### Visualization
 
-Test result metrics are available in the **requests** dimension of your Application Insights instance. 
+Test result metrics are available in the **requests** dimension of your Application Insights instance.
 In the image you can see an example of how you can visualize the duration of the requests made during your test run.
 
 ![Request duration](docs/requestduration.png "Screenshot of test requests duration")
@@ -79,12 +81,12 @@ Additionally, if you enabled `liveMetrics` in the configuration, you can watch y
 
 ## Contributing
 
-Feel free to contribute by forking and making pull requests, or simply by suggesting ideas through the 
+Feel free to contribute by forking and making pull requests, or simply by suggesting ideas through the
 [Issues](https://github.com/adrianmo/jmeter-backend-azure/issues) section.
 
 ### Build
 
-You can make changes to the plugin and build your own JAR file to test changes. To build the artifact, 
+You can make changes to the plugin and build your own JAR file to test changes. To build the artifact,
 execute below Maven command. Make sure `JAVA_HOME` is set properly.
 
 ```bash

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -43,8 +43,8 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final String KEY_CUSTOM_PROPERTIES_PREFIX = "ai.";
     private static final String KEY_HEADERS_PREFIX = "aih.";
     private static final String KEY_RESPONSE_HEADERS = "responseHeaders";
-    private static final String KEY_LOG_RESPONSE = "logResponse";
-    
+    private static final String KEY_LOG_RESPONSE_DATA = "logResponseData";
+
     /**
      * Default argument values.
      */
@@ -53,7 +53,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final boolean DEFAULT_LIVE_METRICS = true;
     private static final String DEFAULT_SAMPLERS_LIST = "";
     private static final boolean DEFAULT_USE_REGEX_FOR_SAMPLER_LIST = false;
-    private static final boolean DEFAULT_LOG_RESPONSE = false;
+    private static final boolean DEFAULT_LOG_RESPONSE_DATA = false;
 
     /**
      * Separator for samplers list.
@@ -101,9 +101,9 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private Set<String> samplersToFilter;
 
     /**
-     * Whether to log the response to the backend
+     * Whether to log the response data to the backend
      */
-    private boolean logResponse;
+    private boolean logResponseData;
 
     public AzureBackendClient() {
         super();
@@ -117,7 +117,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         arguments.addArgument(KEY_LIVE_METRICS, Boolean.toString(DEFAULT_LIVE_METRICS));
         arguments.addArgument(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST);
         arguments.addArgument(KEY_USE_REGEX_FOR_SAMPLER_LIST, Boolean.toString(DEFAULT_USE_REGEX_FOR_SAMPLER_LIST));
-        arguments.addArgument(KEY_LOG_RESPONSE, Boolean.toString(DEFAULT_LOG_RESPONSE));
+        arguments.addArgument(KEY_LOG_RESPONSE_DATA, Boolean.toString(DEFAULT_LOG_RESPONSE_DATA));
 
         return arguments;
     }
@@ -128,7 +128,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         liveMetrics = context.getBooleanParameter(KEY_LIVE_METRICS, DEFAULT_LIVE_METRICS);
         samplersList = context.getParameter(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST).trim();
         useRegexForSamplerList = context.getBooleanParameter(KEY_USE_REGEX_FOR_SAMPLER_LIST, DEFAULT_USE_REGEX_FOR_SAMPLER_LIST);
-        logResponse = context.getBooleanParameter(KEY_LOG_RESPONSE, DEFAULT_LOG_RESPONSE);
+        logResponseData = context.getBooleanParameter(KEY_LOG_RESPONSE_DATA, DEFAULT_LOG_RESPONSE_DATA);
 
         Iterator<String> iterator = context.getParameterNamesIterator();
         while (iterator.hasNext()) {
@@ -205,8 +205,8 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
             req.setUrl(sr.getURL());
         }
 
-        if (logResponse) {
-            properties.put("Response", sr.getResponseDataAsString());
+        if (logResponseData) {
+            properties.put("ResponseData", sr.getResponseDataAsString());
         }
 
         MapUtil.copy(properties, req.getProperties());

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -43,6 +43,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final String KEY_CUSTOM_PROPERTIES_PREFIX = "ai.";
     private static final String KEY_HEADERS_PREFIX = "aih.";
     private static final String KEY_RESPONSE_HEADERS = "responseHeaders";
+    private static final String KEY_LOG_RESPONSE = "logResponse";
     
     /**
      * Default argument values.
@@ -52,6 +53,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final boolean DEFAULT_LIVE_METRICS = true;
     private static final String DEFAULT_SAMPLERS_LIST = "";
     private static final boolean DEFAULT_USE_REGEX_FOR_SAMPLER_LIST = false;
+    private static final boolean DEFAULT_LOG_RESPONSE = false;
 
     /**
      * Separator for samplers list.
@@ -98,6 +100,11 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
      */
     private Set<String> samplersToFilter;
 
+    /**
+     * Whether to log the response to the backend
+     */
+    private boolean logResponse;
+
     public AzureBackendClient() {
         super();
     }
@@ -110,6 +117,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         arguments.addArgument(KEY_LIVE_METRICS, Boolean.toString(DEFAULT_LIVE_METRICS));
         arguments.addArgument(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST);
         arguments.addArgument(KEY_USE_REGEX_FOR_SAMPLER_LIST, Boolean.toString(DEFAULT_USE_REGEX_FOR_SAMPLER_LIST));
+        arguments.addArgument(KEY_LOG_RESPONSE, Boolean.toString(DEFAULT_LOG_RESPONSE));
 
         return arguments;
     }
@@ -120,6 +128,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         liveMetrics = context.getBooleanParameter(KEY_LIVE_METRICS, DEFAULT_LIVE_METRICS);
         samplersList = context.getParameter(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST).trim();
         useRegexForSamplerList = context.getBooleanParameter(KEY_USE_REGEX_FOR_SAMPLER_LIST, DEFAULT_USE_REGEX_FOR_SAMPLER_LIST);
+        logResponse = context.getBooleanParameter(KEY_LOG_RESPONSE, DEFAULT_LOG_RESPONSE);
 
         Iterator<String> iterator = context.getParameterNamesIterator();
         while (iterator.hasNext()) {
@@ -194,6 +203,10 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
 
         if (sr.getURL() != null) {
             req.setUrl(sr.getURL());
+        }
+
+        if (logResponse) {
+            properties.put("Response", sr.getResponseDataAsString());
         }
 
         MapUtil.copy(properties, req.getProperties());


### PR DESCRIPTION
Added a default-false option to persist existing behavior

This allows additional information from the request response to be sent to App Insights. We are using this feature to log and capture query diagnostics from our CosmosDB plugin, but should work for any JMeter plugins seamlessly. 