### PR TITLE
Update AzureBackendClient.java

### DIFF
--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -213,7 +213,8 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         if (sr.getURL() != null) {
             req.setUrl(sr.getURL());
         }
-
+if (sr.getErrorCount() != 0)
+{
         if (logSampleData) {
             req.getProperties().put("SampleData", sr.getSamplerData());
         }
@@ -221,7 +222,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         if (logResponseData) {
             properties.put("ResponseData", sr.getResponseDataAsString());
         }
-
+ }
         MapUtil.copy(properties, req.getProperties());
         telemetryClient.trackRequest(req);
     }


### PR DESCRIPTION
Sending All the SampleData and Response Payload might not be required in any business case, as there will be too much logs, but we might want to store data in case there is some failure.
Hence updated the code to Only Send SampleData and Response payload if error Occurred.