### PR TITLE
Enabled Different options for user to select to send SampleData/ResponseData as required.

### DIFF
--- a/.github/workflows/maven-publish.1yml
+++ b/.github/workflows/maven-publish.1yml
@@ -1,0 +1,43 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+      with:
+    name: jmeter-backendlistener-azure
+    path: target/*.jar
+      !target/*-javadoc.jar
+      !target/*-sources.jar
+      !target/original-*.jar
+    if-no-files-found: warn
+      env:
+        JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/8.0.362-9/x64
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-publish.1yml
+++ b/.github/workflows/maven-publish.1yml
@@ -27,16 +27,17 @@ jobs:
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-      with:
-    name: jmeter-backendlistener-azure
-    path: target/*.jar
-      !target/*-javadoc.jar
-      !target/*-sources.jar
-      !target/original-*.jar
-    if-no-files-found: warn
-      env:
-        JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/8.0.362-9/x64
-
+      
+    - name: Attach JAR as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: jmeter-backendlistener-azure
+          path: |
+            target/*.jar
+            !target/*-javadoc.jar
+            !target/*-sources.jar
+            !target/original-*.jar
+    
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:

--- a/.github/workflows/maven-publish.1yml
+++ b/.github/workflows/maven-publish.1yml
@@ -3,9 +3,7 @@
 
 name: Maven Package
 
-on:
-  release:
-    types: [created]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ Then, in the Parameters table, configure the following attributes.
 | *instrumentationKey* | The Instrumentation Key of your Application Insights instance. <br>⚠️ **Deprecated**: use *connectionString* instead. | No |
 
 *Example of configuration:*
-
-![Screenshot of configuration](docs/configuration.jpg "Screenshot of JMeter configuration")
+![image](https://user-images.githubusercontent.com/46219412/232789063-023f578e-069c-4f29-bf7c-64292f1aaa0c.png)
 
 #### Custom properties
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Then, in the Parameters table, configure the following attributes.
 | *samplersList* | Optional list of samplers separated by a semi-colon (`;`) that the listener will collect and send metrics to Application Insights. If the list is empty, the listener will not filter samplers and send metrics from all of them. Defaults to an empty string. | No |
 | *useRegexForSamplerList* | If set to `true` the `samplersList` will be evaluated as a regex to filter samplers. Defaults to `false`. | No |
 | *responseHeaders* | Optional list of response headers separated by a semi-colon (`;`) that the listener will collect and send values to Application Insights. | No |
-| *logResponseData* | Boolean to indicate whether or not the response data should be captured. If set to `true`, the response data will be captured as a string into the _ResponseData_ property. Defaults to `false`. | No |
-| *logSampleData* | Boolean to indicate whether or not the sample data should be captured. If set to `true`, the sample data will be captured as a string into the _SampleData_ property. Defaults to `false`. | No | 
+| *logResponseDataOption* | Option to Selected "onError"/"always"/"None", if onError is selected if any sample fails ResponseData of that sample will also be logged and incase of always, responseData will be saved adlways , if selected Nothing/None, ReponseData will never be saved  Defaults to `onError`. | No |
+| *logSampleDataOption* | Option to Selected "onError"/"always"/"None", if onError is selected if any sample fails SanpleData of that sample will also be logged and incase of always, SampleData will be saved adlways , if selected Nothing/None, SampleData will never be saved  Defaults to `onError`. | No | 
 | *instrumentationKey* | The Instrumentation Key of your Application Insights instance. <br>⚠️ **Deprecated**: use *connectionString* instead. | No |
 
 *Example of configuration:*

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -46,7 +46,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     //private static final String KEY_LOG_RESPONSE_DATA = "logResponseData";
     private static final String KEY_LOG_RESPONSE_DATA_OPTION = "logResponseDataOption";
     //private static final String KEY_LOG_SAMPLE_DATA = "logSampleData";
-    private static final String KEY_LOG_SAMPLE_DATA_OPTION = "logResponseDataOption";
+    private static final String KEY_LOG_SAMPLE_DATA_OPTION = "logSampleDataOption";
 
     /**
      * Default argument values.
@@ -57,7 +57,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final String DEFAULT_SAMPLERS_LIST = "";
     private static final boolean DEFAULT_USE_REGEX_FOR_SAMPLER_LIST = false;
    //private static final boolean DEFAULT_LOG_RESPONSE_DATA = false;
-    private static final String DEFAULT_LOG_RESPONSE_DATA_OPTION = "OnError";
+    private static final String DEFAULT_LOG_RESPONSE_DATA_OPTION = "onError";
     //private static final boolean DEFAULT_LOG_SAMPLE_DATA = false;
     private static final String DEFAULT_LOG_SAMPLE_DATA_OPTION = "onError";
 

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -213,7 +213,8 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         if (sr.getURL() != null) {
             req.setUrl(sr.getURL());
         }
-
+if (sr.getErrorCount() != 0)
+{
         if (logSampleData) {
             req.getProperties().put("SampleData", sr.getSamplerData());
         }
@@ -221,7 +222,7 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         if (logResponseData) {
             properties.put("ResponseData", sr.getResponseDataAsString());
         }
-
+ }
         MapUtil.copy(properties, req.getProperties());
         telemetryClient.trackRequest(req);
     }

--- a/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
+++ b/src/main/java/io/github/adrianmo/jmeter/backendlistener/azure/AzureBackendClient.java
@@ -43,8 +43,10 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final String KEY_CUSTOM_PROPERTIES_PREFIX = "ai.";
     private static final String KEY_HEADERS_PREFIX = "aih.";
     private static final String KEY_RESPONSE_HEADERS = "responseHeaders";
-    private static final String KEY_LOG_RESPONSE_DATA = "logResponseData";
-    private static final String KEY_LOG_SAMPLE_DATA = "logSampleData";
+    //private static final String KEY_LOG_RESPONSE_DATA = "logResponseData";
+    private static final String KEY_LOG_RESPONSE_DATA_OPTION = "logResponseDataOption";
+    //private static final String KEY_LOG_SAMPLE_DATA = "logSampleData";
+    private static final String KEY_LOG_SAMPLE_DATA_OPTION = "logResponseDataOption";
 
     /**
      * Default argument values.
@@ -54,8 +56,10 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     private static final boolean DEFAULT_LIVE_METRICS = true;
     private static final String DEFAULT_SAMPLERS_LIST = "";
     private static final boolean DEFAULT_USE_REGEX_FOR_SAMPLER_LIST = false;
-    private static final boolean DEFAULT_LOG_RESPONSE_DATA = false;
-    private static final boolean DEFAULT_LOG_SAMPLE_DATA = false;
+   //private static final boolean DEFAULT_LOG_RESPONSE_DATA = false;
+    private static final String DEFAULT_LOG_RESPONSE_DATA_OPTION = "OnError";
+    //private static final boolean DEFAULT_LOG_SAMPLE_DATA = false;
+    private static final String DEFAULT_LOG_SAMPLE_DATA_OPTION = "onError";
 
     /**
      * Separator for samplers list.
@@ -105,12 +109,21 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
     /**
      * Whether to log the response data to the backend
      */
-    private boolean logResponseData;
+    //private boolean logResponseData;
+    /**
+     * Option value selected for response data which can be sent to the backend
+     */
+    private String logResponseDataOption;
 
     /**
      * Whether to log the sample data to the backend
      */
-    private boolean logSampleData;
+    //private boolean logSampleData;
+
+    /**
+     * Option value selected for sample data which can be sent to the backend
+     */
+    private String logSampleDataOption;
 
     public AzureBackendClient() {
         super();
@@ -124,8 +137,10 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         arguments.addArgument(KEY_LIVE_METRICS, Boolean.toString(DEFAULT_LIVE_METRICS));
         arguments.addArgument(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST);
         arguments.addArgument(KEY_USE_REGEX_FOR_SAMPLER_LIST, Boolean.toString(DEFAULT_USE_REGEX_FOR_SAMPLER_LIST));
-        arguments.addArgument(KEY_LOG_RESPONSE_DATA, Boolean.toString(DEFAULT_LOG_RESPONSE_DATA));
-        arguments.addArgument(KEY_LOG_SAMPLE_DATA, Boolean.toString(DEFAULT_LOG_SAMPLE_DATA));
+        //arguments.addArgument(KEY_LOG_RESPONSE_DATA, Boolean.toString(DEFAULT_LOG_RESPONSE_DATA));
+        arguments.addArgument(KEY_LOG_RESPONSE_DATA_OPTION, DEFAULT_LOG_RESPONSE_DATA_OPTION);
+        //arguments.addArgument(KEY_LOG_SAMPLE_DATA, Boolean.toString(DEFAULT_LOG_SAMPLE_DATA));
+        arguments.addArgument(KEY_LOG_SAMPLE_DATA_OPTION, DEFAULT_LOG_SAMPLE_DATA_OPTION);
 
         return arguments;
     }
@@ -136,8 +151,13 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         liveMetrics = context.getBooleanParameter(KEY_LIVE_METRICS, DEFAULT_LIVE_METRICS);
         samplersList = context.getParameter(KEY_SAMPLERS_LIST, DEFAULT_SAMPLERS_LIST).trim();
         useRegexForSamplerList = context.getBooleanParameter(KEY_USE_REGEX_FOR_SAMPLER_LIST, DEFAULT_USE_REGEX_FOR_SAMPLER_LIST);
-        logResponseData = context.getBooleanParameter(KEY_LOG_RESPONSE_DATA, DEFAULT_LOG_RESPONSE_DATA);
-        logSampleData = context.getBooleanParameter(KEY_LOG_SAMPLE_DATA, DEFAULT_LOG_SAMPLE_DATA);
+        //logResponseData = context.getBooleanParameter(KEY_LOG_RESPONSE_DATA, DEFAULT_LOG_RESPONSE_DATA);
+        logResponseDataOption = context.getParameter(KEY_LOG_RESPONSE_DATA_OPTION, DEFAULT_LOG_RESPONSE_DATA_OPTION);
+        //logSampleData = context.getBooleanParameter(KEY_LOG_SAMPLE_DATA, DEFAULT_LOG_SAMPLE_DATA);
+        logSampleDataOption = context.getParameter(KEY_LOG_SAMPLE_DATA_OPTION, DEFAULT_LOG_SAMPLE_DATA_OPTION);
+        log.warn("Logging Response Data on  "+logResponseDataOption);
+        log.warn("Logging Sample Data on  "+logSampleDataOption);
+
 
         Iterator<String> iterator = context.getParameterNamesIterator();
         while (iterator.hasNext()) {
@@ -213,16 +233,30 @@ public class AzureBackendClient extends AbstractBackendListenerClient {
         if (sr.getURL() != null) {
             req.setUrl(sr.getURL());
         }
-if (sr.getErrorCount() != 0)
-{
-        if (logSampleData) {
+// Verify what Option for SampleData Collection is Selected if 'onError' is Selected And Error is observed, Log it
+        if (logSampleDataOption.equals("onError")) {
+            // If There is error Reported Log the Message
+            if (sr.getErrorCount() != 0)
+            {
+            req.getProperties().put("SampleData", sr.getSamplerData());
+        }
+        }
+        // Else Check if 'always' Selected, Always Log Sample Data
+        else if (logSampleDataOption.equals("always")) {
             req.getProperties().put("SampleData", sr.getSamplerData());
         }
 
-        if (logResponseData) {
+// Verify what Option for ResponseData Collection is Selected if 'onError' is Selected And Error is observed, Log it
+        if (logResponseDataOption.equals("onError")) {
+            if (sr.getErrorCount() != 0) {
+                properties.put("ResponseData", sr.getResponseDataAsString());
+            }
+        }
+        // Else Check if 'always' Selected, Always Log Response Data
+        else if (logResponseDataOption.equals("always")) {
             properties.put("ResponseData", sr.getResponseDataAsString());
         }
- }
+
         MapUtil.copy(properties, req.getProperties());
         telemetryClient.trackRequest(req);
     }


### PR DESCRIPTION
Enabled Different options for user to select to send SampleData/ResponseData as required.
onError - Default 
always 
if nothing passed or any value passed apart from onError or always, It does not send logs.
readme.md file also updated with snapshot and option details.